### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/ihuicatl/jupyter-rospkg/compare/v0.1.0a...2db021169cd141b14f7f49ef5448cabf526a561c))
+
+### Enhancements made
+
+- Add packages server [#3](https://github.com/ihuicatl/jupyter-rospkg/pull/3) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Bugs fixed
+
+- First release checks [#5](https://github.com/ihuicatl/jupyter-rospkg/pull/5) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/ihuicatl/jupyter-rospkg/graphs/contributors?from=2022-09-08&to=2022-09-09&type=c))
+
+[@ihuicatl](https://github.com/search?q=repo%3Aihuicatl%2Fjupyter-rospkg+involves%3Aihuicatl+updated%3A2022-09-08..2022-09-09&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | ihuicatl/jupyter-rospkg  |
| Branch  | main  |
| Version Spec | 0.2.0 |
| Since | v0.1.0a |