### PR TITLE
Automated Changelog Entry for 0.2.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.1
+
+([Full Changelog](https://github.com/ihuicatl/jupyter-rospkg/compare/v0.2.0...017479dea5077702fce3455fe0cdb0bebdcd6f4c))
+
+### Bugs fixed
+
+- Update dependencies and README [#7](https://github.com/ihuicatl/jupyter-rospkg/pull/7) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Documentation improvements
+
+- Update dependencies and README [#7](https://github.com/ihuicatl/jupyter-rospkg/pull/7) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/ihuicatl/jupyter-rospkg/graphs/contributors?from=2022-09-09&to=2022-09-15&type=c))
+
+[@ihuicatl](https://github.com/search?q=repo%3Aihuicatl%2Fjupyter-rospkg+involves%3Aihuicatl+updated%3A2022-09-09..2022-09-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.0
 
 ([Full Changelog](https://github.com/ihuicatl/jupyter-rospkg/compare/v0.1.0a...2db021169cd141b14f7f49ef5448cabf526a561c))
@@ -19,5 +39,3 @@
 ([GitHub contributors page for this release](https://github.com/ihuicatl/jupyter-rospkg/graphs/contributors?from=2022-09-08&to=2022-09-09&type=c))
 
 [@ihuicatl](https://github.com/search?q=repo%3Aihuicatl%2Fjupyter-rospkg+involves%3Aihuicatl+updated%3A2022-09-08..2022-09-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/ihuicatl/jupyter-rospkg/releases/tag/untagged-a4ab0259ae4200443f87  |
| Since | v0.2.0 |