### PR TITLE
Automatically enable server extension during installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling>=1.3.1", "jupyterlab~=3.1"]
-build-backend = "hatchling.build"
+requires = ["jupyter_packaging~=0.12,<2", "jupyterlab~=3.1"]
+build-backend = "jupyter_packaging.build_api"
 
 [project]
 name = "jupyter_rospkg"

--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,95 @@
-__import__('setuptools').setup()
+# __import__('setuptools').setup()
+# import json
+import sys
+from pathlib import Path
+
+import setuptools
+
+HERE = Path(__file__).parent.resolve()
+
+# The name of the project
+name = "jupyter-rospkg"
+
+# lab_path = (HERE / name.replace("-", "_") / "labextension")
+
+# Representative files that should exist after a successful build
+# ensured_targets = [
+#     str(lab_path / "package.json"),
+#     str(lab_path / "static/style.js")
+# ]
+
+# labext_name = "@jupyterlab-examples/server-extension"
+
+data_files_spec = [
+    # ("share/jupyter/labextensions/%s" % labext_name, str(lab_path.relative_to(HERE)), "**"),
+    # ("share/jupyter/labextensions/%s" % labext_name, str("."), "install.json"),
+    ("etc/jupyter/jupyter_server_config.d",
+     "jupyter-config/server-config", "jupyter_rospkg.json"),
+    # For backward compatibility with notebook server
+    ("etc/jupyter/jupyter_notebook_config.d",
+     "jupyter-config/nb-config", "jupyter_rospkg.json"),
+]
+
+long_description = (HERE / "README.md").read_text()
+
+# Get the package info from package.json
+# pkg_json = json.loads((HERE / "package.json").read_bytes())
+
+setup_args = dict(
+    name=name,
+    version="jupyter-rospkg",
+    url="https://github.com/ihuicatl/jupyter-rospkg",
+    author="Isabel Paredes",
+    author_email="isabel.paredes@quantstack.net",
+    description="A server extension for JupyterLab to handle ROS packages",
+    license="BSD-3-Clause",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        "jupyter_server>=1.6,<2"
+    ],
+    extras_require = {
+        'dev': [
+            'click',
+            'jupyter_packaging>=0.11'
+        ]
+    },
+    zip_safe=False,
+    include_package_data=True,
+    python_requires=">=3.6",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
+    classifiers=[
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Framework :: Jupyter",
+    ],
+)
+
+try:
+    from jupyter_packaging import (
+        # wrap_installers,
+        # npm_builder,
+        get_data_files
+    )
+    # post_develop = npm_builder(
+    #     build_cmd="install:extension", source_dir="src", build_dir=lab_path
+    # )
+    # setup_args["cmdclass"] = wrap_installers(post_develop=post_develop, ensured_targets=ensured_targets)
+    setup_args["data_files"] = get_data_files(data_files_spec)
+except ImportError as e:
+    import logging
+    logging.basicConfig(format="%(levelname)s: %(message)s")
+    logging.warning("Build tool `jupyter-packaging` is missing. Install it with pip or conda.")
+    if not ("--name" in sys.argv or "--version" in sys.argv):
+        raise e
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)


### PR DESCRIPTION
Currently, the server extension needs to be manually enabled after it has been installed.
```
jupyter server extension enable jupyter_rospkg
```

With this PR, this step will be automated.